### PR TITLE
Fix: cached access token always treated as expired (token rotation storm)

### DIFF
--- a/src/Api.ts
+++ b/src/Api.ts
@@ -303,7 +303,9 @@ export class AccessTokenHandlerFileStorage implements AccessTokenHandlerInterfac
         if (fs.existsSync(this._accessTokenFilePath)) {
             let accessTokenFileContent = JSON.parse(fs.readFileSync(this._accessTokenFilePath, 'utf-8'));
             let accessToken = new AccessToken(accessTokenFileContent);
-            if (accessToken.request_time + accessToken.expires_in > (Date.now() * 1000)) {
+            const expiresAt = Number(accessToken.request_time) + Number(accessToken.expires_in);
+            const nowSeconds = Math.floor(Date.now() / 1000);
+            if (expiresAt > nowSeconds) {
                 return accessToken;
             }
         }


### PR DESCRIPTION
## Summary

The cached access token validation in `AccessTokenHandlerFileStorage.get()` always returns `null` (treats the token as expired), so the client regenerates a fresh token on every API call. After a handful of calls Oblio invalidates older tokens on each new issuance, causing _all_ subsequent requests to fail with `"The access token provided has expired"` — even with a token that was issued seconds ago.

## Root cause

```ts
if (accessToken.request_time + accessToken.expires_in > (Date.now() * 1000))
```

Two compounding bugs:

1. `request_time` and `expires_in` arrive from the Oblio API as **strings** (`"request_time": "1777976183"`, `"expires_in": "3600"`). `+` is string concatenation, not addition: `"1777976183" + "3600"` → `"17779761833600"`.
2. The right-hand side is in **microseconds** (`Date.now()` is already milliseconds, multiplying by 1000 gives microseconds), while `request_time + expires_in` is in **seconds**. The comparison crosses unit boundaries.

The `AccessToken` class declares the fields as `number`, but TypeScript types are not enforced at runtime — the data preserves the original string types from the JSON response.

## Fix

Coerce both operands to `Number` and compare seconds against seconds:

\`\`\`ts
const expiresAt = Number(accessToken.request_time) + Number(accessToken.expires_in);
const nowSeconds = Math.floor(Date.now() / 1000);
if (expiresAt > nowSeconds) {
    return accessToken;
}
\`\`\`

## Reproduction

Make 4–5 API calls in quick succession (e.g. \`createInvoice\` followed by \`collect\` and \`get\`). The first 1–2 succeed; the rest fail with `"The access token provided has expired"`. Inspect the network: every call posts to \`/api/authorize/token\` first, regenerating the access token. After Oblio's token-rotation policy kicks in, even fresh tokens come back invalidated.

## Impact

This is the difference between an SDK that works for the first call and one that works reliably under any load. It also explains intermittent CI flakes and the recurring `[object Object]` errors users see in tooling that wraps this SDK (the wrappers swallow the error message because `OblioApiException` does not extend `Error`).

## Test plan

- [x] Manual: ran the same SDK build with the same credentials before/after — without the fix every other call returned `expired`; with the fix all calls succeed against a cached token.
- [ ] No unit tests in the repo today; happy to add one mocking the file storage if maintainers want.

🤖 Generated with [Claude Code](https://claude.com/claude-code)